### PR TITLE
Response

### DIFF
--- a/src/ASyncServer/src/CMakeLists.txt
+++ b/src/ASyncServer/src/CMakeLists.txt
@@ -9,4 +9,5 @@ target_link_libraries(${MODULE_NAME}_lib
   PUBLIC Utils_lib
   PUBLIC Sys_lib
   PUBLIC Net_lib
+  PUBLIC HTTP_lib
   )

--- a/src/ASyncServer/src/Client.cpp
+++ b/src/ASyncServer/src/Client.cpp
@@ -1,6 +1,6 @@
 #include "Client.hpp"
 
-Client::Client(void) : state(Client::Inactive), reader() {}
+Client::Client(void) : state(Client::Inactive), reader(), parser() {}
 
 Client::~Client(void) {}
 
@@ -59,3 +59,44 @@ bool Client::eof(void) {
     }
     return reader.eof();
 }
+
+bool Client::parse_http(void) {
+    std::string line;
+    size_t lines_read = 0;
+
+    while (!eof()) {
+        Utils::RwResult read_result = read_line(line);
+        if (read_result.is_err()) {
+            // TODO indicates failure of ::read. Should be unlikely, but if it does occur
+            // then 500 Internal Server Error should be set as Response
+        } else {
+            size_t bytes_read = read_result.unwrap();
+            if (bytes_read == 0)
+                break;
+            parser.parse_line(Slice(line));
+            line.clear();
+            lines_read += 1;
+        }
+
+        if (lines_read == 0) {
+            state = Close; // If select is triggered with 0 bytes to send, the client has closed
+                           // connection
+            break;
+        }
+    }
+    return parser.is_complete();
+}
+
+http::Request::Result Client::generate_request(void) { return parser.generate_request(); }
+
+// if (parser.is_complete()) {
+//   http::Request::Result req_res = parser.generate_request();
+//   if (req_res.is_err()) {
+//     std::cout << "Invalid request:" << std::endl;
+//     std::cout << req_res.unwrap_err() << std::endl;
+//   } else {
+//     std::cout << "Valid request: " << std::endl;
+//     std::cout << req_res.unwrap();
+//   }
+//   parser = http::Request::Parser();
+// }

--- a/src/ASyncServer/src/Client.cpp
+++ b/src/ASyncServer/src/Client.cpp
@@ -106,15 +106,3 @@ http::Request::Result Client::generate_request(void) {
 
     return parser.generate_request();
 }
-
-// if (parser.is_complete()) {
-//   http::Request::Result req_res = parser.generate_request();
-//   if (req_res.is_err()) {
-//     std::cout << "Invalid request:" << std::endl;
-//     std::cout << req_res.unwrap_err() << std::endl;
-//   } else {
-//     std::cout << "Valid request: " << std::endl;
-//     std::cout << req_res.unwrap();
-//   }
-//   parser = http::Request::Parser();
-// }

--- a/src/ASyncServer/src/Client.cpp
+++ b/src/ASyncServer/src/Client.cpp
@@ -1,8 +1,6 @@
 #include "Client.hpp"
 
-Client::Client(void) : state(Client::Inactive), reader(), data() {
-    data.reserve(CLIENT_BUFFER_SIZE);
-}
+Client::Client(void) : state(Client::Inactive), reader() {}
 
 Client::~Client(void) {}
 

--- a/src/ASyncServer/src/Client.hpp
+++ b/src/ASyncServer/src/Client.hpp
@@ -1,12 +1,13 @@
 #ifndef CLIENT_HPP
 #define CLIENT_HPP
 
+#include "../../HTTP/src/Request.hpp"
 #include "../../Net/src/TcpStream.hpp"
 #include "../../Sys/src/BufReader.hpp"
 
 class Client {
   public:
-    enum Status { Connected, Read, Processing, RequestReady, Write, Inactive };
+    enum Status { Connected, Read, Processing, RequestReady, Write, Close, Inactive };
 
   public:
     Client(void);
@@ -27,11 +28,15 @@ class Client {
 
     bool eof(void);
 
+    bool parse_http(void);
+    http::Request::Result generate_request(void);
+
   public:
     Client::Status state;
 
   private:
     BufReader<TcpStream> reader;
+    http::Request::Parser parser;
 };
 
 #endif

--- a/src/ASyncServer/src/Client.hpp
+++ b/src/ASyncServer/src/Client.hpp
@@ -4,8 +4,6 @@
 #include "../../Net/src/TcpStream.hpp"
 #include "../../Sys/src/BufReader.hpp"
 
-#define CLIENT_BUFFER_SIZE 1024
-
 class Client {
   public:
     enum Status { Connected, Read, Processing, RequestReady, Write, Inactive };
@@ -34,7 +32,6 @@ class Client {
 
   private:
     BufReader<TcpStream> reader;
-    std::string data;
 };
 
 #endif

--- a/src/Examples/src/CMakeLists.txt
+++ b/src/Examples/src/CMakeLists.txt
@@ -1,22 +1,36 @@
 # Add new executable targets here to serve as examples
 
-add_executable(Select.run Select.cpp)
+set(BINARY Select)
 
-target_link_libraries(Select.run
+add_executable(${BINARY}.run ${BINARY}.cpp)
+
+target_link_libraries(${BINARY}.run
     PUBLIC Slice_lib
     PUBLIC Net_lib
     PUBLIC ASyncServer_lib
 	)
 
-add_executable(BufReader.run BufReader.cpp)
+set(BINARY BufReader)
 
-target_link_libraries(BufReader.run
+add_executable(${BINARY}.run ${BINARY}.cpp)
+
+target_link_libraries(${BINARY}.run
     PUBLIC Sys_lib
 	)
 
-add_executable(HttpRequest.run HttpRequest.cpp)
+set(BINARY HttpRequest)
 
-target_link_libraries(HttpRequest.run
+add_executable(${BINARY}.run ${BINARY}.cpp)
+
+target_link_libraries(${BINARY}.run
   PUBLIC Net_lib
   PUBLIC HTTP_lib
+	)
+
+set(BINARY ClientParsing)
+
+add_executable(${BINARY}.run ${BINARY}.cpp)
+
+target_link_libraries(${BINARY}.run
+  PUBLIC ASyncServer_lib
 	)

--- a/src/Examples/src/ClientParsing.cpp
+++ b/src/Examples/src/ClientParsing.cpp
@@ -1,0 +1,45 @@
+// Very similar to Select.cpp, using a server to read data from a Client.
+// This server however, will parse data in the form of an HTTP request, and
+// print the generated response on the Server's terminal.
+
+#include <iostream>
+
+#include "../../ASyncServer/src/Server.hpp"
+#include "../../HTTP/src/Request.hpp"
+#include "../../Result/src/result.hpp"
+
+typedef std::vector<Client*>::iterator client_it;
+
+void handle_client(Client& client) {
+    std::string message_received;
+    std::string message_sent;
+
+    if (client.parse_http()) { // True when Request is error, or successfully completed
+        http::Request::Result req_res = client.generate_request();
+
+        if (req_res.is_err()) {
+            std::cout << "Invalid request:" << std::endl;
+            std::cout << req_res.unwrap_err() << std::endl;
+        } else {
+            std::cout << "Valid request: " << std::endl;
+            std::cout << req_res.unwrap();
+        }
+    }
+}
+
+int main(void) {
+    Server server = Server::bind("localhost:4246").unwrap();
+    std::vector<Client*> clients;
+
+    clients.reserve(CLIENT_TOTAL - 1); // 1, as we are using a single TcpListener
+
+    while (true) {
+        server.select(clients);
+
+        for (client_it client = clients.begin(); client != clients.end(); client++) {
+            handle_client(**client);
+        }
+    }
+
+    return 0;
+}

--- a/src/HTTP/src/Request.cpp
+++ b/src/HTTP/src/Request.cpp
@@ -232,8 +232,11 @@ void Request::Parser::parse_line(Slice line) {
     if (line_should_have_CRLF() && !line_has_CRLF(line)) {
         return set_parser_state(Error, BadRequest_400);
     }
-    if (step == Headers && line.length() == 2) {
-        step = Processing;
+    if (line.length() == 2) {
+        if (step == Headers)
+            step = Processing;
+        else if (step == Method) // Ignore leading CRLF's
+            return;
     }
 
     switch (step) {
@@ -265,14 +268,20 @@ Utils::optional<size_t> Request::Parser::ready_for_body(void) const {
     return content_length;
 }
 
+// generate_request() will also reset the Parser
 Request::Result Request::Parser::generate_request(void) {
     if (error != OK_200) {
-        return Request::Result::Err(error);
+        State return_error = error;
+        *this = Request::Parser();
+        return Request::Result::Err(return_error);
     } else if (step != Complete) {
+        *this = Request::Parser();
         // Message is incomplete, and therefore, badly formed
         return Request::Result::Err(BadRequest_400);
     } else {
-        return Request::Result::Ok(builder.build());
+        Request request = builder.build();
+        *this = Request::Parser();
+        return Request::Result::Ok(request);
     }
 }
 

--- a/src/HTTP/src/Request.cpp
+++ b/src/HTTP/src/Request.cpp
@@ -67,45 +67,6 @@ std::ostream& operator<<(std::ostream& o, Version const& ver) {
     return o;
 }
 
-// 'State' class. Essentially acts as an enum, but with additional functionality,
-// primarily the ability to be converted to a const char* with the enum name,
-// which allows the use of 'State' as an Error return value in Utils::result.
-
-Request::State::State(void) : inner(OK_200) {}
-
-Request::State::State(e_State state) : inner(state) {}
-
-Request::State::~State(void) {}
-
-Request::State::State(State const& src) : inner(src.inner) {}
-
-Request::State& Request::State::operator=(State const& rhs) {
-    if (&rhs == this) {
-        return *this;
-    }
-    inner = rhs.inner;
-    return *this;
-}
-
-const char* Request::State::enum_strings[] = {
-    "OK_200",
-    "BadRequest_400",
-    "LengthRequired_411",
-    "URITooLong_414",
-    "HeaderTooLarge_431",
-    "NotImplemented_501",
-    "HttpNotSupported_505",
-};
-
-Request::State::operator e_State() const { return inner; }
-
-Request::State::operator const char*() const { return enum_strings[inner]; }
-
-std::ostream& operator<<(std::ostream& o, Request::State const& state) {
-    o << static_cast<const char*>(state);
-    return o;
-}
-
 Request::Builder::Builder(void) : method_(GET), uri_("/"), version_(HTTP_11), headers() {}
 
 Request::Builder::~Builder(void) {}
@@ -139,7 +100,6 @@ Request::Builder& Request::Builder::header(Slice key, Slice val) {
     std::map<std::string, std::string>::iterator search = headers.find(key);
 
     if (search != headers.end()) {
-        // If header exists, append new value to end, separated by comma
         search->second.append(", ").append(val);
     } else {
         headers.insert(std::make_pair(key, val));
@@ -151,7 +111,6 @@ Request::Builder& Request::Builder::header(std::string const& key, std::string c
     std::map<std::string, std::string>::iterator search = headers.find(key);
 
     if (search != headers.end()) {
-        // If header exists, append new value to end, separated by comma
         search->second += ", " + val;
     } else {
         headers.insert(std::make_pair(key, val));

--- a/src/HTTP/src/Request.hpp
+++ b/src/HTTP/src/Request.hpp
@@ -9,6 +9,7 @@
 #include "../../Result/src/result.hpp"
 #include "../../Slice/src/Slice.hpp"
 #include "../../Utils/src/Utils.hpp"
+#include "State.hpp"
 
 #define URI_SIZE_LIMIT 2048
 #define HEADER_SIZE_LIMIT 4096
@@ -80,33 +81,6 @@ std::ostream& operator<<(std::ostream& o, Version const& ver);
 
 class Request {
   public:
-    enum e_State {
-        OK_200,
-        BadRequest_400,
-        LengthRequired_411,
-        URITooLong_414,
-        HeaderTooLarge_431,
-        NotImplemented_501,
-        HttpNotSupported_505,
-    };
-
-    class State {
-      public:
-        State(void);
-        State(e_State state);
-        ~State(void);
-        State(State const& src);
-        State& operator=(State const& rhs);
-
-        operator e_State() const;
-        operator const char*() const;
-
-      private:
-        e_State inner;
-
-        static const char* enum_strings[];
-    };
-
     typedef Utils::result<Request, State> Result;
 
     friend std::ostream& operator<<(std::ostream&, Request const&);
@@ -219,9 +193,6 @@ class Request {
     static const std::map<const Slice, bool> valid_headers;
     static const std::map<const Slice, Version> valid_versions;
 };
-
-std::string& operator+(std::string& lhs, Request::State const& rhs);
-std::ostream& operator<<(std::ostream& o, Request::State const& state);
 
 } // namespace http
 

--- a/src/HTTP/src/Response.cpp
+++ b/src/HTTP/src/Response.cpp
@@ -1,0 +1,121 @@
+#include "Response.hpp"
+
+namespace http {
+
+// http::Response Builder class
+
+Response::Builder::Builder(void) : state_(OK_200), version_(HTTP_11) {}
+
+Response::Builder::~Builder(void) {}
+
+Response::Builder::Builder(Builder const& src) { *this = src; }
+
+Response::Builder& Response::Builder::operator=(Builder const& rhs) {
+    if (&rhs == this) {
+        return *this;
+    }
+    Builder& ref = const_cast<Builder&>(rhs); // move semantics
+    state_ = rhs.state_;
+    version_ = rhs.version_;
+    headers.swap(ref.headers);
+    body_.swap(ref.body_);
+
+    return *this;
+}
+
+Response::Builder& Response::Builder::header(const char* key, const char* val) {
+    return header(Slice(key), Slice(val));
+}
+
+Response::Builder& Response::Builder::header(Slice key, Slice val) {
+    std::map<std::string, std::string>::iterator search = headers.find(key);
+
+    if (search != headers.end()) {
+        search->second.append(", ").append(val);
+    } else {
+        headers.insert(std::make_pair(key, val));
+    }
+    return *this;
+}
+
+Response::Builder& Response::Builder::header(std::string const& key, std::string const& val) {
+    std::map<std::string, std::string>::iterator search = headers.find(key);
+
+    if (search != headers.end()) {
+        search->second += ", " + val;
+    } else {
+        headers.insert(std::make_pair(key, val));
+    }
+    return *this;
+}
+
+Response::Builder& Response::Builder::version(Version new_version) {
+    version_ = new_version;
+    return *this;
+}
+
+Response::Builder& Response::Builder::body(std::string new_body) {
+    body_.swap(new_body);
+    return *this;
+}
+
+Response::Builder& Response::Builder::append_to_body(Slice const& slice) {
+    append_slice_to_string(body_, slice);
+    return *this;
+}
+
+Response Response::Builder::build(void) { return Response(state_, version_, headers, body_); }
+
+// http::Response class
+
+Response::Response(void) : state(OK_200), version(HTTP_11) {}
+
+Response::Response(State new_state, Version new_version,
+                   std::map<std::string, std::string>& new_headers, std::string& new_body)
+    : state(new_state), version(new_version) {
+    headers.swap(new_headers);
+    body.swap(new_body);
+}
+
+Response::~Response(void) {}
+
+Response::Response(Response const& src) { *this = src; }
+
+Response& Response::operator=(Response const& rhs) {
+    if (&rhs == this) {
+        return *this;
+    }
+    Response& mut_ref = const_cast<Response&>(rhs); // move semantics
+    state = rhs.state;
+    version = rhs.version;
+    headers.swap(mut_ref.headers);
+    body.swap(mut_ref.body);
+    return *this;
+}
+
+std::string Response::to_string(void) const {
+    std::string output =
+        static_cast<std::string>(version) + " " + static_cast<std::string>(state) + "\r\n";
+    for (std::map<std::string, std::string>::const_iterator header = headers.begin();
+         header != headers.end(); header++) {
+        output += header->first + ": " + header->second + "\r\n";
+    }
+    output += "\r\n";
+
+    return output;
+}
+
+std::ostream& operator<<(std::ostream& o, Response const& response) {
+    o << response.version << " ";
+    o << static_cast<const char*>(response.state) << "\r\n";
+    for (std::map<std::string, std::string>::const_iterator header = response.headers.begin();
+         header != response.headers.end(); header++) {
+        o << header->first << ": " << header->second << "\r\n";
+    }
+    o << "\r\n";
+    o << response.body;
+
+    return o;
+}
+
+} // namespace http

--- a/src/HTTP/src/Response.cpp
+++ b/src/HTTP/src/Response.cpp
@@ -101,6 +101,7 @@ std::string Response::to_string(void) const {
         output += header->first + ": " + header->second + "\r\n";
     }
     output += "\r\n";
+    output += body;
 
     return output;
 }

--- a/src/HTTP/src/Response.hpp
+++ b/src/HTTP/src/Response.hpp
@@ -1,0 +1,77 @@
+#ifndef RESPONSE_HPP
+#define RESPONSE_HPP
+
+#include <iostream>
+#include <map>
+#include <string>
+
+#include "Request.hpp"
+#include "State.hpp"
+
+namespace http {
+
+// Required Response Headers
+// - Allow (Valid methods for specified resource - use with err 405) (Allow: GET, HEAD)
+// - Content-Language
+// - Content-Length
+// - Content-Location
+// - Content-Type
+// - Date (In HTTP-date format)
+// - Last-Modified
+// - Location
+// - Retry-After
+// - Server
+// - Transfer-Encoding
+// - WWW-Authenticate
+
+class Response {
+  public:
+    friend std::ostream& operator<<(std::ostream&, Response const&);
+
+  public:
+    class Builder {
+      public:
+        Builder(void);
+        ~Builder(void);
+        Builder(Builder const& src);
+        Builder& operator=(Builder const& rhs);
+
+        Builder& header(const char* key, const char* val);
+        Builder& header(Slice key, Slice val);
+        Builder& header(std::string const& key, std::string const& val);
+        Builder& version(Version new_version);
+        Builder& body(std::string new_body);
+        Builder& append_to_body(Slice const& slice);
+
+        Response build(void);
+
+      private:
+        State state_;
+        Version version_;
+        std::map<std::string, std::string> headers;
+        std::string body_;
+    };
+
+  public:
+    ~Response(void);
+    Response(Response const& src);
+    Response& operator=(Response const& rhs);
+
+    std::string to_string(void) const;
+
+  private:
+    State state;
+    Version version;
+    std::map<std::string, std::string> headers;
+    std::string body;
+
+    Response(void);
+    Response(State new_state, Version new_version, std::map<std::string, std::string>& new_headers,
+             std::string& new_body);
+};
+
+std::ostream& operator<<(std::ostream& o, Response const& response);
+
+} // namespace http
+
+#endif

--- a/src/HTTP/src/State.cpp
+++ b/src/HTTP/src/State.cpp
@@ -1,0 +1,40 @@
+#include "State.hpp"
+
+namespace http {
+
+State::State(void) : inner(OK_200) {}
+
+State::State(e_State state) : inner(state) {}
+
+State::~State(void) {}
+
+State::State(State const& src) : inner(src.inner) {}
+
+State& State::operator=(State const& rhs) {
+    if (&rhs == this) {
+        return *this;
+    }
+    inner = rhs.inner;
+    return *this;
+}
+
+const char* State::enum_strings[] = {
+    "200 OK",
+    "400 Bad Request",
+    "411 Length Required",
+    "414 URI Too Long",
+    "431 Request Header Fields Too Large",
+    "501 Not Implemented",
+    "505 HTTP Version Not Supported",
+};
+
+State::operator e_State() const { return inner; }
+
+State::operator const char*() const { return enum_strings[inner]; }
+
+std::ostream& operator<<(std::ostream& o, State const& state) {
+    o << static_cast<const char*>(state);
+    return o;
+}
+
+} // namespace http

--- a/src/HTTP/src/State.hpp
+++ b/src/HTTP/src/State.hpp
@@ -1,0 +1,39 @@
+#ifndef STATE_HPP
+#define STATE_HPP
+
+#include <iostream>
+#include <string>
+
+namespace http {
+enum e_State {
+    OK_200,
+    BadRequest_400,
+    LengthRequired_411,
+    URITooLong_414,
+    HeaderTooLarge_431,
+    NotImplemented_501,
+    HttpNotSupported_505,
+};
+
+class State {
+  public:
+    State(void);
+    State(e_State state);
+    ~State(void);
+    State(State const& src);
+    State& operator=(State const& rhs);
+
+    operator e_State() const;
+    operator const char*() const;
+
+  private:
+    e_State inner;
+
+    static const char* enum_strings[];
+};
+std::string& operator+(std::string& lhs, State const& rhs);
+std::ostream& operator<<(std::ostream& o, State const& state);
+
+} // namespace http
+
+#endif

--- a/src/HTTP/tst/Request.cpp
+++ b/src/HTTP/tst/Request.cpp
@@ -124,6 +124,17 @@ TEST(RequestParser, empty) {
     EXPECT_EQ(request_state, Request::BadRequest_400);
 }
 
+TEST(RequestParser, ignore_leading_crlf) {
+    Request::Parser parser;
+
+    parser.parse_line("\r\n");
+    EXPECT_FALSE(parser.is_complete());
+
+    parser.parse_line("GET / HTTP/1.0\r\n");
+    parser.parse_line("\r\n");
+    EXPECT_TRUE(parser.is_complete());
+}
+
 TEST(RequestParser, headers) {
     Request::Parser parser;
 

--- a/src/HTTP/tst/Request.cpp
+++ b/src/HTTP/tst/Request.cpp
@@ -56,18 +56,18 @@ TEST(Request, with_body) {
 }
 
 TEST(RequestParser, state) {
-    Request::State state = Request::OK_200;
-    EXPECT_EQ(state, Request::OK_200);
-    EXPECT_STREQ(state, "OK_200");
+    State state = OK_200;
+    EXPECT_EQ(state, OK_200);
+    EXPECT_STREQ(state, "200 OK");
 
-    state = Request::BadRequest_400;
-    EXPECT_EQ(state, Request::BadRequest_400);
-    EXPECT_STREQ(state, "BadRequest_400");
+    state = BadRequest_400;
+    EXPECT_EQ(state, BadRequest_400);
+    EXPECT_STREQ(state, "400 Bad Request");
 
     std::string str("State is: ");
 
     str.append(state);
-    EXPECT_EQ(str, "State is: BadRequest_400");
+    EXPECT_EQ(str, "State is: 400 Bad Request");
 }
 
 TEST(RequestParser, method) {
@@ -99,7 +99,7 @@ TEST(RequestParser, invalid_http) {
     Request::Result req_res = parser.generate_request();
 
     EXPECT_TRUE(req_res.is_err());
-    EXPECT_EQ(req_res.unwrap_err(), Request::HttpNotSupported_505);
+    EXPECT_EQ(req_res.unwrap_err(), HttpNotSupported_505);
 }
 
 TEST(RequestParser, no_crlf) {
@@ -110,7 +110,7 @@ TEST(RequestParser, no_crlf) {
 
     Request::Result req_res = parser.generate_request();
     EXPECT_TRUE(req_res.is_err());
-    EXPECT_EQ(req_res.unwrap_err(), Request::BadRequest_400);
+    EXPECT_EQ(req_res.unwrap_err(), BadRequest_400);
 }
 
 TEST(RequestParser, empty) {
@@ -119,9 +119,9 @@ TEST(RequestParser, empty) {
     Request::Result req_res = parser.generate_request();
 
     EXPECT_FALSE(req_res.is_ok());
-    Request::State request_state = req_res.unwrap_err();
+    State request_state = req_res.unwrap_err();
 
-    EXPECT_EQ(request_state, Request::BadRequest_400);
+    EXPECT_EQ(request_state, BadRequest_400);
 }
 
 TEST(RequestParser, ignore_leading_crlf) {
@@ -253,5 +253,5 @@ TEST(RequestParser, body_chunked_no_crlf) {
 
     ASSERT_TRUE(req_res.is_err());
 
-    EXPECT_EQ(req_res.unwrap_err(), Request::BadRequest_400);
+    EXPECT_EQ(req_res.unwrap_err(), BadRequest_400);
 }

--- a/src/HTTP/tst/Response.cpp
+++ b/src/HTTP/tst/Response.cpp
@@ -36,8 +36,16 @@ TEST(Response, headers) {
                                     "\r\n");
 }
 
-// TEST(Response, body) {
-//   Response response = Response::Builder()
-//     .header("Age", "86415")
-//     .build();
-// }
+TEST(Response, body) {
+    Response response = Response::Builder()
+                            .header("Age", "86415")
+                            .header("Content-Length", "40")
+                            .append_to_body("This is a message body from an http resp")
+                            .build();
+
+    EXPECT_EQ(response.to_string(), "HTTP/1.1 200 OK\r\n"
+                                    "Age: 86415\r\n"
+                                    "Content-Length: 40\r\n"
+                                    "\r\n"
+                                    "This is a message body from an http resp");
+}

--- a/src/HTTP/tst/Response.cpp
+++ b/src/HTTP/tst/Response.cpp
@@ -1,0 +1,43 @@
+#include <gtest/gtest.h>
+
+#include "../src/Response.hpp"
+
+#include <iostream>
+
+using namespace http;
+
+TEST(Response, default_initialization) {
+    Response response = Response::Builder().build();
+
+    EXPECT_EQ(response.to_string(), "HTTP/1.1 200 OK\r\n\r\n");
+}
+
+TEST(Response, version) {
+    Response response = Response::Builder().version(HTTP_09).build();
+
+    EXPECT_EQ(response.to_string(), "HTTP/0.9 200 OK\r\n\r\n");
+}
+
+TEST(Response, headers) {
+    Response response = Response::Builder()
+                            .header("Content-Encoding", "gzip")
+                            .header("Accept-Ranges", "bytes")
+                            .header("Age", "86415")
+                            .header("Cache-Control", "max-age=604800")
+                            .header("Etag", "\"3147526947\"")
+                            .build();
+
+    EXPECT_EQ(response.to_string(), "HTTP/1.1 200 OK\r\n"
+                                    "Accept-Ranges: bytes\r\n"
+                                    "Age: 86415\r\n"
+                                    "Cache-Control: max-age=604800\r\n"
+                                    "Content-Encoding: gzip\r\n"
+                                    "Etag: \"3147526947\"\r\n"
+                                    "\r\n");
+}
+
+// TEST(Response, body) {
+//   Response response = Response::Builder()
+//     .header("Age", "86415")
+//     .build();
+// }

--- a/src/Net/src/Socket.cpp
+++ b/src/Net/src/Socket.cpp
@@ -2,6 +2,7 @@
 #include "../../Utils/src/Utils.hpp"
 #include <cerrno>
 #include <cstring>
+#include <fcntl.h>
 
 size_t Socket::READ_LIMIT = 512;
 

--- a/src/Net/src/SocketAddr.cpp
+++ b/src/Net/src/SocketAddr.cpp
@@ -5,7 +5,7 @@ SocketAddrV4::SocketAddrV4(void) {}
 
 SocketAddrV4::~SocketAddrV4(void) {}
 
-SocketAddrV4::SocketAddrV4(SocketAddrV4 const& other) : inner(other.inner) {}
+SocketAddrV4::SocketAddrV4(SocketAddrV4 const& other) { inner = other.inner; }
 
 SocketAddrV4 SocketAddrV4::operator=(SocketAddrV4 const& rhs) {
     if (this == &rhs) {

--- a/src/Net/src/TcpStream.cpp
+++ b/src/Net/src/TcpStream.cpp
@@ -2,13 +2,14 @@
 #include "../../Utils/src/Utils.hpp"
 #include <cerrno>
 #include <cstring>
+#include <fcntl.h>
 #include <vector>
 
 TcpStream::TcpStream(void) : inner() {}
 
 TcpStream::~TcpStream(void) {}
 
-TcpStream::TcpStream(Socket sock) : inner(sock) {}
+TcpStream::TcpStream(Socket sock) : inner(sock) { fcntl(sock.into_inner(), F_SETFL, O_NONBLOCK); }
 
 TcpStream::TcpStream(TcpStream const& other) { *this = other; }
 

--- a/src/Utils/src/CMakeLists.txt
+++ b/src/Utils/src/CMakeLists.txt
@@ -3,3 +3,7 @@ file(GLOB_RECURSE SOURCES LIST_DIRECTORIES true *.hpp *.cpp)
 set(SOURCES ${SOURCES})
 
 add_library(${MODULE_NAME}_lib STATIC ${SOURCES})
+
+target_link_libraries(${MODULE_NAME}_lib
+  PUBLIC Slice_lib
+  )

--- a/src/Utils/src/Utils.cpp
+++ b/src/Utils/src/Utils.cpp
@@ -6,14 +6,17 @@
 /*   By: rlucas <marvin@codam.nl>                     +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2021/03/17 19:05:37 by rlucas        #+#    #+#                 */
-/*   Updated: 2021/05/03 17:18:57 by rlucas        ########   odam.nl         */
+/*   Updated: 2021/05/07 17:15:08 by rlucas        ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "Utils.hpp"
+#include "../../Slice/src/Slice.hpp"
 
 // Uncomment to show src files are compiled with std=c++98
 // #include <array>
+
+#include <iostream>
 
 namespace Utils {
 // Uncomment to show src files are compiled with std=c++98
@@ -188,6 +191,8 @@ long atol_length(const char* str, size_t length) {
     return static_cast<long>(result * sign);
 }
 
+// runtime_error class
+
 runtime_error::runtime_error(void) : _msg("Undefined error") {}
 
 runtime_error::~runtime_error(void) throw() {}
@@ -207,4 +212,72 @@ runtime_error& runtime_error::operator=(runtime_error const& rhs) {
 }
 
 const char* runtime_error::what(void) const throw() { return (_msg.c_str()); }
+
+// Time class
+
+Time::Time(time_t time_val) : inner(time_val) {}
+
+Time::~Time(void) {}
+
+Time::Time(Time const& src) : inner(src.inner) {}
+
+Time& Time::operator=(Time const& rhs) {
+    if (&rhs == this) {
+        return *this;
+    }
+    inner = rhs.inner;
+    return *this;
+}
+
+Time Time::now(void) {
+    time_t timer;
+
+    ::time(&timer);
+    return Time(timer);
+}
+
+std::string Time::to_string(void) {
+    struct tm* timeinfo;
+    std::string output;
+
+    Utils::memset(buf, '\0', 26);
+
+    timeinfo = localtime(&inner);
+    asctime_r(timeinfo, buf);
+    std::cout << buf << std::endl;
+    for (size_t i = 0; i < 26; i++) {
+        if (buf[i])
+            output += buf[i];
+    }
+    return output;
+}
+
+std::string Time::to_http_string(void) {
+    to_string();
+    Slice original = Slice::newSlice(buf);
+
+    Slice::Split iter = original.split();
+    std::string output;
+
+    Slice day_name = iter.next();
+    Slice month = iter.next();
+    Slice day_num = iter.next();
+    Slice time = iter.next();
+    Slice year = iter.next();
+
+    output.append(day_name)
+        .append(", ")
+        .append(day_num)
+        .append(" ")
+        .append(month)
+        .append(" ")
+        .append(year)
+        .append(" ")
+        .append(time)
+        .append(" ")
+        .append("GMT+2");
+
+    return output;
+}
+
 } // namespace Utils

--- a/src/Utils/src/Utils.hpp
+++ b/src/Utils/src/Utils.hpp
@@ -2,6 +2,7 @@
 #define UTILS_HPP
 
 #include <cstddef>
+#include <ctime>
 #include <exception>
 #include <string>
 
@@ -149,6 +150,25 @@ class array_unique_ptr {
 
   private:
     pointer _p;
+};
+
+class Time {
+  public:
+    ~Time(void);
+    Time(Time const& src);
+    Time& operator=(Time const& rhs);
+
+    static Time now(void);
+
+    std::string to_string(void);
+    std::string to_http_string(void);
+
+  private:
+    time_t inner;
+    char buf[26];
+
+    Time(void);
+    Time(time_t time_val);
 };
 
 } // namespace Utils

--- a/src/Utils/tst/time_tests.cpp
+++ b/src/Utils/tst/time_tests.cpp
@@ -1,0 +1,5 @@
+#include <gtest/gtest.h>
+
+#include "../src/Utils.hpp"
+
+TEST(Time, current_time) { std::cout << Utils::Time::now().to_http_string() << std::endl; }

--- a/tst/HttpParsing.cpp
+++ b/tst/HttpParsing.cpp
@@ -3,13 +3,45 @@
 #include "../src/ASyncServer/src/Server.hpp"
 #include "../src/HTTP/src/Request.hpp"
 
+#include <chrono>
 #include <iostream>
+#include <thread>
+
+// Prototypes
+typedef std::vector<Client*>::iterator client_it;
+static std::string handle_client(Client& client);
+static void client_func(const char* address, const char* message);
+
+// Mock class (I think that's the term?)
 
 class RequestTests : public ::testing::Test {
   public:
     Server server;
     std::vector<Client*> clients;
     const char* address_info;
+
+    std::thread message_send(const char* request_message) {
+        const char* address_copy = address_info;
+        return std::thread([&address_copy, &request_message](void) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(30));
+            client_func(address_copy, request_message);
+        });
+    }
+
+    void expected_request(const char* expected_request) {
+        size_t connections_received = 0;
+        std::string actual;
+
+        while (connections_received < 1) {
+            server.select(clients);
+
+            connections_received += clients.size();
+            for (client_it client = clients.begin(); client != clients.end(); client++) {
+                actual = handle_client(**client);
+                EXPECT_EQ(actual, expected_request);
+            }
+        }
+    }
 
     void SetUp(void) override {
         address_info = "localhost:4250";
@@ -23,12 +55,64 @@ class RequestTests : public ::testing::Test {
     }
 };
 
-TEST_F(RequestTests, parse_message_from_socket) {
-    // TODO Complete test once HTTP Parsing has been integrated into Client
-    while (true) {
-        break;
-        server.select(clients);
+// client_func() represents an external client
+static void client_func(const char* address, const char* message) {
+    TcpStream client =
+        TcpStream::connect(address).expect("Unable to contact TcpListener from client thread");
+    client.write(message);
+}
+
+// handle_client() represents the code that will exist in our WebServer.
+// In this test file, it simply returns a string either representing the error
+// generated from the Request Parsing, or the well-formed request.
+static std::string handle_client(Client& client) {
+    std::string message_received;
+    std::string message_sent;
+
+    client.parse_http();
+
+    http::Request::Result req_res = client.generate_request();
+
+    if (req_res.is_err()) {
+        return static_cast<const char*>(req_res.unwrap_err());
+    } else {
+        return req_res.unwrap().to_string();
     }
+}
+
+// Tests
+
+TEST_F(RequestTests, basic_message_parse) {
+    std::thread client_thread = message_send("GET / HTTP/1.1\r\nHost:example.com\r\n\r\n");
+    expected_request("GET / HTTP/1.1\r\nHost: example.com\r\n\r\n");
+    client_thread.join();
+}
+
+TEST_F(RequestTests, empty_message_parse) {
+    std::thread client_thread = message_send("aaaaaaa");
+    expected_request("BadRequest_400");
+    client_thread.join();
+}
+
+TEST_F(RequestTests, post_message_parse) {
+    std::thread client_thread =
+        message_send("POST / HTTP/1.1\r\nContent-Length: 10\r\n\r\ndata=hello");
+    expected_request("POST / HTTP/1.1\r\nContent-Length: 10\r\n\r\ndata=hello");
+    client_thread.join();
+}
+
+// Data beyond Content-Length is ignored
+TEST_F(RequestTests, post_message_too_much_data) {
+    std::thread client_thread = message_send(
+        "POST / HTTP/1.1\r\nContent-Length: 10\r\n\r\ndata=hello_there\r\nmoredata=goodbye");
+    expected_request("POST / HTTP/1.1\r\nContent-Length: 10\r\n\r\ndata=hello");
+    client_thread.join();
+}
+
+TEST_F(RequestTests, post_message_no_length) {
+    std::thread client_thread = message_send("POST / HTTP/1.1\r\n\r\ndata=hello\r\n");
+    expected_request("LengthRequired_411");
+    client_thread.join();
 }
 
 int main(int argc, char** argv) {

--- a/tst/HttpParsing.cpp
+++ b/tst/HttpParsing.cpp
@@ -88,7 +88,7 @@ TEST_F(RequestTests, basic_message_parse) {
 
 TEST_F(RequestTests, empty_message_parse) {
     std::thread client_thread = message_send("aaaaaaa");
-    expected_request("BadRequest_400");
+    expected_request("400 Bad Request");
     client_thread.join();
 }
 
@@ -109,7 +109,7 @@ TEST_F(RequestTests, post_message_too_much_data) {
 
 TEST_F(RequestTests, post_message_no_length) {
     std::thread client_thread = message_send("POST / HTTP/1.1\r\n\r\ndata=hello\r\n");
-    expected_request("LengthRequired_411");
+    expected_request("411 Length Required");
     client_thread.join();
 }
 
@@ -127,7 +127,7 @@ TEST_F(RequestTests, post_chunked_incomplete) {
     std::thread client_thread = message_send("POST / HTTP/1.1\r\nTransfer-Encoding: chunked\r\n\r\n"
                                              "10\r\n"
                                              "data=hello\r\n");
-    expected_request("BadRequest_400");
+    expected_request("400 Bad Request");
     client_thread.join();
 }
 


### PR DESCRIPTION
http::Response class added, with Builder.

The class is relatively small and simple - and there is no need for an associated Parser class as with the http::Request.
The Response::Builder class should be built up following the change of a Client's state to Write - at this point, the stored Request::Builder from the Client will be used to generate a Request.

From this Request, invalid or valid, a http::Response will be built - before being sent to the Client.