### PR TITLE
Readme: display the right statusbadge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The Webserv project from the 42 Curriculum.
 
-[![build](https://github.com/rlucas585/webserv/workflows/Unittests/badge.svg?branch=develop)](https://github.com/rlucas585/webserv/actions?workflow=Unittests)
+[![format](https://github.com/rlucas585/webserv/workflows/Clang-format/badge.svg?branch=develop)](https://github.com/rlucas585/webserv/actions?workflow=Clang-format)
 [![linux](https://github.com/rlucas585/webserv/workflows/Linux/badge.svg?branch=develop)](https://github.com/rlucas585/webserv/actions?workflow=Linux)
 [![macos](https://github.com/rlucas585/webserv/workflows/MacOS/badge.svg?branch=develop)](https://github.com/rlucas585/webserv/actions?workflow=MacOS)
 


### PR DESCRIPTION
Whilst casually ripping the github actions, my eye caught this catastrophic bug